### PR TITLE
Fix missing --root_path argument causing AttributeError in avatar_reenact.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,15 @@ We also provide a script for cross-reenactment:
 python avatar_reenact.py \
     --config <CONFIG_PATH> \
     --model_name <MODEL_NAME> \
+    --root_path <ROOT_PATH>
     --dst_path <DATASET_PATH> \
     --workspace <EXP_DIR> \
     --name <EXP_NAME> \
 ```
+
+- `--root_path`:
+  
+  Path to the source head avatar dataset.
 
 - `--dst_path`:
 

--- a/avatar_reenact.py
+++ b/avatar_reenact.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--config',     type=str,                       required=True)
     parser.add_argument('--model_name', choices=ModelCallbacks.keys(),  required=True)
+    parser.add_argument('--root_path',  type=str,                       required=True)
     parser.add_argument('--dst_path',   type=str,                       required=True)
     parser.add_argument('--workspace',  type=str,                       required=True)
     parser.add_argument('--name',       type=str,                       required=True)
@@ -39,7 +40,8 @@ if __name__ == "__main__":
         overrides={
             "name":         opt.name,
             "workspace":    opt.workspace,
-            "bg_color":     opt.bg_color
+            "bg_color":     opt.bg_color,
+            "dst_path":     opt.dst_path,
             }
         )
 


### PR DESCRIPTION
Hi @zjwfufu, Thank you for sharing this excellent project!

While exploring the codebase, I found a small bug in the cross-reenactment script that I'd like to contribute to fix.

## Issue
`AttributeError: 'Namespace' object has no attribute 'root_path'` error occurs when running `avatar_reenact.py`.

## Root Cause
- `construct_datasets` function in `common.py` uses `opt.root_path`
- `avatar_reenact.py` doesn't define the `--root_path` argument

## Changes Made
1. **avatar_reenact.py**: Added `--root_path` argument and config overriding (`dst_path: opt.dst_path`)
2. **README.md**: Added `--root_path` argument description to usage examples

## Testing
- Verified AttributeError is resolved
- Confirmed cross-reenactment script works properly